### PR TITLE
Allow different length of a string for each "iteration"

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,6 @@ Parser.prototype._transform = function (chunk, encoding, done) {
         this.res[step.name] = step.fn.apply(this.res, [chunk, this.offset]);
         this.offset += stepLength;
         this.idx++;
-
-        if (this.steps[i+1] && typeof this.steps[i+1].length === 'string') {
-          this.steps[i+1].length = this.res[this.steps[i+1].length];
-        }
       }
 
       if (i === this.steps.length - 1) {
@@ -126,17 +122,17 @@ Parser.prototype.string = function (name, length, encoding) {
   if (!encoding) encoding = 'utf8';
   var self = this;
   return self.next(name, length, function (chunk, offset) {
-    if (typeof length === 'string') length = this[length];
-    return chunk.toString(encoding, offset, offset + length);
+    var len = (typeof length === 'string') ? this[length] : length;
+    return chunk.toString(encoding, offset, offset + len);
   });
 };
 
 Parser.prototype.buffer = function (name, length) {
   var self = this;
   return self.next(name, length, function (chunk, offset) {
-    if (typeof length === 'string') length = this[length];
-    var buf = new Buffer(length);
-    chunk.copy(buf, 0, offset, offset + length);
+    var len = (typeof length === 'string') ? this[length] : length;
+    var buf = new Buffer(len);
+    chunk.copy(buf, 0, offset, offset + len);
     return buf;
   });
 };

--- a/test/string.js
+++ b/test/string.js
@@ -1,0 +1,34 @@
+var test = require('tape');
+var parse = require('..');
+
+test('variable string lengths', function (t) {
+  var parser = parse()
+    .readUInt8('length')
+    .string('str', 'length')
+    .string('str2', 'length')
+
+  var i = 0;
+  parser.on('data', function (data) {
+    if (i === 0) {
+      t.deepEqual(data, { length : 3, str : 'foo',  str2 : 'bar'  });
+    } else {
+      t.deepEqual(data, { length : 4, str : 'abcd', str2 : 'efgh' });
+      t.end();
+    }
+    i++;
+  });
+
+  var buf = new Buffer(7);
+  buf.writeUInt8(3, 0);
+  buf.write('foo', 1);
+  buf.write('bar', 4);
+
+  var buf2 = new Buffer(9);
+  buf2.writeUInt8(4, 0);
+  buf2.write('abcd', 1);
+  buf2.write('efgh', 5);
+  console.log(buf2);
+
+  parser.write(buf);
+  parser.write(buf2);
+});


### PR DESCRIPTION
Imagine you have:

``` javascript
var parser = parse()
    .readUInt8('length')
    .string('str', 'length')

parser.on('data', console.log);

parser.write(new Buffer([1, 0x30])); // { length: 1, str: '0'}
parser.write(new Buffer([2, 0x31, 0x32])); // { length: 2, str: '12' }
```

First chunk works fine.
For the second chunk of data, it thinks that the length is still 1, so `str` will be `'1'` (`length` is still read as `2`, but is kinda ignored).
Hence the offset is +1, instead of +2, which creates big problems if another chunk is written, ie: `length` will be read as `0x32`, instead of `0x2` (but hell.., it doesn't matter. it will think the length is `1` anyways..)

This pull request is an attempt to fix that behavior.
